### PR TITLE
Fix `wrapLine` algorithm

### DIFF
--- a/rewrapper.mjs
+++ b/rewrapper.mjs
@@ -44,15 +44,17 @@ function wrapLines(lines, columnLength) {
 
 function wrapLine(line, columnLength) {
   const leadingIndent = getLeadingIndent(line, columnLength);
+  line = line.trimLeft();
 
   const brokenLines = [];
-  let currentLine = "";
+  let currentLine = leadingIndent;
   let spaceBefore = "";
   for (const word of line.split(" ")) {
     if (currentLine.length + spaceBefore.length + word.length < columnLength) {
       currentLine += spaceBefore + word;
     } else {
-      brokenLines.push(currentLine);
+      if (currentLine != leadingIndent)
+        brokenLines.push(currentLine);
       currentLine = leadingIndent + word;
     }
     spaceBefore = " ";

--- a/rewrapper.mjs
+++ b/rewrapper.mjs
@@ -53,7 +53,7 @@ function wrapLine(line, columnLength) {
     if (currentLine.length + spaceBefore.length + word.length < columnLength) {
       currentLine += spaceBefore + word;
     } else {
-      if (currentLine != leadingIndent)
+      if (currentLine !== leadingIndent)
         brokenLines.push(currentLine);
       currentLine = leadingIndent + word;
     }

--- a/testcases/single-word-exactly-column-length.html
+++ b/testcases/single-word-exactly-column-length.html
@@ -1,0 +1,1 @@
+       <p>This-word-is-99-characters-long-so-with-a-new-line-character-it-is-exactly-100-chars-long Next</p>

--- a/testcases/single-word-exactly-column-length.out.html
+++ b/testcases/single-word-exactly-column-length.out.html
@@ -1,0 +1,2 @@
+       <p>This-word-is-99-characters-long-so-with-a-new-line-character-it-is-exactly-100-chars-long
+       Next</p>

--- a/testcases/single-word-too-long.html
+++ b/testcases/single-word-too-long.html
@@ -1,0 +1,1 @@
+       <p>This-is-a-single-word-that-is-longer-than-the-allowed-column-length-but-there-was-a-bug-that-always-printed-a-newline-first. Next.</p>

--- a/testcases/single-word-too-long.out.html
+++ b/testcases/single-word-too-long.out.html
@@ -1,0 +1,2 @@
+       <p>This-is-a-single-word-that-is-longer-than-the-allowed-column-length-but-there-was-a-bug-that-always-printed-a-newline-first.
+       Next.</p>


### PR DESCRIPTION
Copied from the commit description:

```
This commit fixes a bug in the `wrapLine` algorithm which caused a single line
comprised only of indentation to be printed before any other lines, in the case
where the the input's first word was too long for the allowed column length.

This can be observed by going to https://domenic.github.io/rewrapper and
inputting:

       <p>This-specification-is-intended-for-authors-of-documents-and-scripts-that-use-the-features-blah-blah-blah.

The reason the output would have a random preceding newline full of only
indentation (but only 6 spaces, instead of 7!), is because each space in the
indentation was being considered as a word of length 0. This meant that for each
space in the initial indentation, we'd hit the first path of the `if` condition
in the `for` loop, which would incrementally build `currentLine` up to to
`leadingIndent.length` - ` number of `spaceBefore`s.

Once we finally got to the first real word, if that word made `currentLine` too
long, we would commit `currentLine` (of only indentation) to `brokenLines` and
continue.

This is wrong and weird. To prevent us from committing a line of only spaces to
the output, this commit adds a check to ensure that we don't do this.

That leaves us with the fact that we're still computing the first line really
weird, by treating each leading space as a separate word. For all subsequent
lines, we eagerly tack on `leadingIndent` to the beginning of `currentLine` when
`currentLine` is reset, so we should just do the same for the first line. This
commit changes the initialization of `currentLine` to equal `leadingIndent`
initially, and invokes `line.trimLeft()` right away in the function.
```